### PR TITLE
🔧 Fix: Deploy-dev workflow path filters and directory references

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,7 +4,14 @@ on:
   push:
     branches: [main]
     paths:
+      - 'src/**'
       - 'context-store/**'
+      - 'schemas/**'
+      - 'contracts/**'
+      - 'requirements.txt'
+      - 'Dockerfile'
+      - 'docker-compose*.yml'
+      - '.env*'
       - '.github/workflows/deploy-dev.yml'
   workflow_dispatch:
     inputs:
@@ -348,7 +355,7 @@ jobs:
         run: |
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=~/.ssh/known_hosts -i ~/.ssh/id_ed25519 ${{ secrets.HETZNER_USER }}@${{ secrets.HETZNER_HOST }} << 'EOF'
             echo "🔍 Verifying DEV deployment..."
-            cd /opt/veris-memory/context-store
+            cd /opt/veris-memory
             
             # Show dev containers
             echo "Dev containers running:"


### PR DESCRIPTION
## Problem
The deploy-dev workflow wasn't triggering automatically when PR #11 was merged because:
1. Path filter only included `context-store/**` but our bug fixes were in `src/**`
2. Old directory references to `/opt/veris-memory/context-store` instead of `/opt/veris-memory`

This caused the critical bug fixes to not be deployed automatically.

## Solution
- ✅ Add `src/**`, `schemas/**`, `contracts/**` to path filters 
- ✅ Add `requirements.txt`, `Dockerfile`, `docker-compose*.yml` to path filters
- ✅ Fix directory reference in verification step
- ✅ Enable automatic deployment on actual code changes

## Impact
- Future merges to main will automatically trigger dev deployment
- Current bug fixes from PR #11 will deploy once this is merged
- Maintains backward compatibility with existing workflow structure

🤖 Generated with [Claude Code](https://claude.ai/code)