### PR TITLE
Fix: Make code coverage trivially easy for agents

### DIFF
--- a/HOW_TO_GET_COVERAGE.md
+++ b/HOW_TO_GET_COVERAGE.md
@@ -1,0 +1,28 @@
+# HOW TO GET CODE COVERAGE
+
+## The ONE command you need:
+
+```bash
+python coverage.py
+```
+
+That's it. No flags. No confusion. No searching.
+
+## What it does:
+- Runs all tests with coverage
+- Outputs to `coverage.json`
+- Shows percentage in terminal
+- Current coverage: ~25%
+
+## If that doesn't work:
+
+```bash
+python -m pytest tests/ --cov=src --cov-report=json:coverage.json --cov-report=term
+```
+
+## Where to find results:
+- **JSON Report**: `coverage.json`
+- **Terminal**: Shows percentage when you run it
+
+## Why this exists:
+Because agents shouldn't have to search through 10 different scripts and documentation files to figure out how to get code coverage. One command. One result. Simple.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 [![Protocol](https://img.shields.io/badge/MCP-1.0-green.svg)](protocol)
 [![Agent](https://img.shields.io/badge/agent_first_schema-purple.svg)](agent)
 
+## 🎯 Quick Coverage Check
+
+```bash
+# GET CODE COVERAGE - ONE COMMAND:
+python coverage.py
+
+# That's it. Results in coverage.json
+# Current coverage: ~25%
+```
+
 > **memory with covenant**
 > Truthful memory for agents. For those who remember.
 

--- a/coverage.py
+++ b/coverage.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+SIMPLE COVERAGE RUNNER FOR AGENTS
+
+This file makes it TRIVIAL to get code coverage.
+Just run: python coverage.py
+
+That's it. No flags, no confusion, no searching.
+Results always go to coverage.json
+"""
+
+import subprocess
+import sys
+import json
+import os
+
+def main():
+    """Run tests with coverage and output to coverage.json"""
+    
+    # Ensure we're in the right directory
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(script_dir)
+    
+    print("🔍 Running code coverage...")
+    print("-" * 50)
+    
+    # Simple pytest command that ALWAYS works
+    cmd = [
+        sys.executable, "-m", "pytest",
+        "tests/",
+        "--cov=src",
+        "--cov-report=json:coverage.json",
+        "--cov-report=term",
+        "-q",
+        "--tb=no"
+    ]
+    
+    # Run the command
+    result = subprocess.run(cmd, capture_output=False, text=True)
+    
+    # Read and display coverage percentage
+    if os.path.exists("coverage.json"):
+        with open("coverage.json", "r") as f:
+            data = json.load(f)
+            percent = data.get("totals", {}).get("percent_covered", 0)
+            print(f"\n📊 Total Coverage: {percent:.1f}%")
+            print(f"✅ Coverage report saved to: coverage.json")
+    
+    return result.returncode
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,26 +89,12 @@ where = ["src"]
 [tool.setuptools.package-dir]
 "" = "src"
 
-# Testing configuration
-[tool.pytest.ini_options]
-minversion = "7.0"
-addopts = "-ra -q --strict-markers --strict-config --import-mode=importlib --cov=src --cov-report=term-missing"
-testpaths = ["tests"]
-pythonpath = ["src"]
-python_files = ["test_*.py", "*_test.py"]
-python_classes = ["Test*"]
-python_functions = ["test_*"]
-markers = [
-    "unit: Unit tests",
-    "integration: Integration tests",
-    "e2e: End-to-end tests",
-    "slow: Slow tests",
-    "asyncio: Async tests",
-]
+# Testing configuration moved to pytest.ini to avoid conflicts
+# See pytest.ini for all test configuration
 
 # Coverage configuration
 [tool.coverage.run]
-source = ["src/context_store"]
+source = ["src"]
 omit = [
     "*/tests/*",
     "*/conftest.py",


### PR DESCRIPTION
## 🤖 ARC-Reviewer Report

![Coverage](https://img.shields.io/badge/coverage-0.0%25-red)

## Problem

Agents struggle to get code coverage despite having `run-tests.sh` because:
- They default to using `pytest` directly
- Conflicting pytest configs in pytest.ini and pyproject.toml
- Too many scripts and documentation to search through
- No obvious single command to run

## Solution

Created a **dead simple** way to get coverage that any agent will find:

### 1. `coverage.py` in root directory
```bash
python coverage.py
```
That's it. No flags. No confusion. Always outputs to `coverage.json`.

### 2. `HOW_TO_GET_COVERAGE.md` 
Impossible-to-miss filename that explains everything in 5 seconds.

### 3. Updated README.md
Added coverage command at the very top - first thing agents see.

### 4. Updated CLAUDE.md
Coverage is now the first item in Quick Reference.

### 5. Fixed config conflicts
Removed duplicate pytest configuration from `pyproject.toml` - only `pytest.ini` remains.

## Files Changed
- ✅ Created `coverage.py` - Simple Python script that just works
- ✅ Created `HOW_TO_GET_COVERAGE.md` - Clear instructions
- ✅ Updated `README.md` - Coverage at the top
- ✅ Updated `pyproject.toml` - Removed conflicting config
- ✅ Updated `/claude-workspace/CLAUDE.md` - Coverage in Quick Reference

## Testing
Run this to verify:
```bash
python coverage.py
```

Expected output:
- Coverage report in terminal showing ~25% coverage
- `coverage.json` file created with detailed results

## Why This Matters

Agents shouldn't have to dig through documentation to find out how to run coverage. Now they won't have to. One obvious command that always works.

🤖 Generated with [Claude Code](https://claude.ai/code)