### PR TITLE
fix(monitoring): correct BaseHTTPMiddleware import causing 500 errors

### DIFF
--- a/src/monitoring/request_metrics.py
+++ b/src/monitoring/request_metrics.py
@@ -16,22 +16,10 @@ from typing import Dict, List, Optional, Callable
 from datetime import datetime, timedelta
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
-# Optional FastAPI imports for environments where it's not available
-try:
-    from fastapi import Request, Response, HTTPException
-    from fastapi.middleware.base import BaseHTTPMiddleware
-    FASTAPI_AVAILABLE = True
-except ImportError:
-    # Create dummy classes for testing environments
-    FASTAPI_AVAILABLE = False
-    class Request:
-        pass
-    class Response:
-        pass
-    class HTTPException(Exception):
-        pass
-    class BaseHTTPMiddleware:
-        pass
+# FastAPI imports - these are required dependencies
+from fastapi import Request, Response, HTTPException
+from starlette.middleware.base import BaseHTTPMiddleware
+FASTAPI_AVAILABLE = True
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Critical fix for RequestMetricsMiddleware import issue introduced in PR #54.

**Problem**: MCP server returning 500 errors due to incorrect BaseHTTPMiddleware import
**Solution**: Fix import from fastapi.middleware.base to starlette.middleware.base
**Result**: Health endpoint restored, all services healthy

## Changes Made
- Fixed import path: `fastapi.middleware.base` → `starlette.middleware.base`
- Removed problematic try/catch fallback with dummy classes
- RequestMetricsMiddleware now properly inherits from BaseHTTPMiddleware

## Testing Results
- **Before**: `curl http://localhost:8000/health` → HTTP 500 Error
- **After**: `curl http://localhost:8000/health` → HTTP 200 OK ✅

## Impact
🎯 **Fixes**: All 500 errors on MCP server endpoints
🎯 **Restores**: Health endpoint functionality
🎯 **Enables**: Telegram bot integration with Veris Memory

Tested on production deployment - MCP server now starts correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)