### PR TITLE
Fix: Correct monitoring dashboard Docker command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
       - DASHBOARD_PORT=8080
       - MONITORING_ENABLED=true
       - LOG_LEVEL=info
-    command: ["python", "-m", "src.monitoring.dashboard_api"]
+    command: ["python", "-m", "src.monitoring"]
     depends_on:
       qdrant:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- ✅ Fix Docker command for monitoring dashboard container
- ✅ Change from `src.monitoring.dashboard_api` to `src.monitoring`

## Problem
The monitoring dashboard container was stuck in a restart loop because the Docker command was incorrect:

```yaml
command: ["python", "-m", "src.monitoring.dashboard_api"]  # ❌ Wrong
```

This was trying to run a module that doesn't have a `__main__.py` at that level.

## Solution
Corrected to use the proper entry point:

```yaml
command: ["python", "-m", "src.monitoring"]  # ✅ Correct
```

This uses the `__main__.py` file we created in `src/monitoring/` which properly initializes the dashboard server.

## Test plan
- [x] Docker command points to correct module path
- [x] `src/monitoring/__main__.py` exists and is the proper entry point
- [x] Should resolve container restart loop

## Technical Details
The `src.monitoring` module has a `__main__.py` that:
- Creates FastAPI app with dashboard API
- Configures uvicorn server on port 8080
- Handles proper startup/shutdown

🤖 Generated with [Claude Code](https://claude.ai/code)