### PR TITLE
fix: Correct monitoring-dashboard healthcheck endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,11 +134,11 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/api/dashboard/metrics"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/dashboard"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 30s
+      retries: 5
+      start_period: 90s
     restart: unless-stopped
     networks:
       - context-store-network


### PR DESCRIPTION
## Summary
Fix deployment failure caused by monitoring-dashboard healthcheck using non-existent endpoint.

## Problem
The deployment is failing with:
```
Container veris-memory-dev-monitoring-dashboard-1  Error
dependency failed to start: container veris-memory-dev-monitoring-dashboard-1 is unhealthy
```

The monitoring-dashboard healthcheck was checking `/api/dashboard/metrics` which doesn't exist after the Phase 1-5 cleanup sprint (PR #83).

## Solution
- Changed healthcheck endpoint from `/api/dashboard/metrics` to `/api/dashboard` which actually exists
- Increased `start_period` from 30s to 90s to give the dashboard more time to initialize
- Increased `retries` from 3 to 5 for better resilience

## Impact
This will fix the deployment failure and allow:
- monitoring-dashboard to become healthy
- Sentinel to start successfully (since it depends on monitoring-dashboard)
- Full monitoring stack to be operational

## Testing
After this change, the deployment should succeed with all services healthy.

🤖 Generated with [Claude Code](https://claude.ai/code)