### PR TITLE
fix: Add missing entry point for Sentinel monitoring service

### DIFF
--- a/dockerfiles/Dockerfile.sentinel
+++ b/dockerfiles/Dockerfile.sentinel
@@ -29,4 +29,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
 EXPOSE 9090
 
 # Run Sentinel with standalone mode
-CMD ["python", "-m", "src.monitoring.veris_sentinel", "--standalone", "--api-port", "9090"]
+CMD ["python", "-m", "src.monitoring.sentinel", "--standalone", "--api-port", "9090"]

--- a/src/monitoring/sentinel/__main__.py
+++ b/src/monitoring/sentinel/__main__.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+Sentinel Monitoring Service Entry Point
+
+Run the Sentinel monitoring system as a standalone service.
+"""
+
+import asyncio
+import os
+import sys
+import argparse
+import logging
+
+# Add project root to path for imports
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from src.monitoring.sentinel.runner import SentinelRunner
+from src.monitoring.sentinel.models import SentinelConfig
+
+
+def setup_logging():
+    """Configure logging for Sentinel."""
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(
+        level=getattr(logging, log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    return logging.getLogger(__name__)
+
+
+async def main():
+    """Main entry point for Sentinel monitoring service."""
+    parser = argparse.ArgumentParser(description="Veris Sentinel Monitoring Service")
+    parser.add_argument("--standalone", action="store_true", help="Run in standalone mode")
+    parser.add_argument("--api-port", type=int, default=9090, help="API server port")
+    parser.add_argument("--no-api", action="store_true", help="Disable API server")
+    
+    args = parser.parse_args()
+    
+    logger = setup_logging()
+    logger.info("🚀 Starting Veris Sentinel Monitoring Service")
+    
+    # Create configuration from environment
+    config = SentinelConfig.from_env()
+    
+    # Create and start runner
+    runner = SentinelRunner(config)
+    
+    try:
+        # Start API server if not disabled
+        if not args.no_api:
+            api_task = asyncio.create_task(runner.start_api_server(port=args.api_port))
+            logger.info(f"✅ API server started on port {args.api_port}")
+        
+        # Start monitoring
+        logger.info("✅ Starting monitoring checks")
+        await runner.start_monitoring()
+        
+    except KeyboardInterrupt:
+        logger.info("⚠️ Received shutdown signal")
+    except Exception as e:
+        logger.error(f"❌ Sentinel failed: {e}")
+        sys.exit(1)
+    finally:
+        logger.info("👋 Sentinel shutting down")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
Fix Sentinel container restart loop by adding the missing __main__.py entry point.

## Problem
After PR #85 fixed the monitoring-dashboard healthcheck, Sentinel was still failing with:
```
veris-memory-dev-sentinel-1  Restarting (1) 6 seconds ago
```

The issue was that the Dockerfile was trying to run `python -m src.monitoring.veris_sentinel` but:
1. The module was refactored to `src.monitoring.sentinel` package
2. No `__main__.py` entry point was created for the package

## Solution
1. **Created `src/monitoring/sentinel/__main__.py`** - Proper entry point for the package
2. **Updated Dockerfile.sentinel** - Changed module path from `src.monitoring.veris_sentinel` to `src.monitoring.sentinel`
3. **Added proper initialization** - Argument parsing, logging setup, and integration with SentinelRunner

## Code Changes
The new `__main__.py`:
- Parses command-line arguments (`--standalone`, `--api-port`, `--no-api`)
- Sets up logging from LOG_LEVEL environment variable
- Creates SentinelConfig from environment variables
- Starts the SentinelRunner with API server on port 9090
- Handles graceful shutdown

## Impact
This will fix the Sentinel restart loop and allow:
- Sentinel to start successfully
- All S1-S10 monitoring checks to run
- Telegram alerting to function
- API health endpoint on port 9090

## Testing
After this fix, Sentinel should:
- Start without errors
- Show as healthy in deployment logs
- Be accessible at port 9090 for health checks
- Send alerts to Telegram when issues are detected

🤖 Generated with [Claude Code](https://claude.ai/code)