### PR TITLE
fix(sentinel): Update target URL to FastAPI port 8001

### DIFF
--- a/src/monitoring/sentinel/models.py
+++ b/src/monitoring/sentinel/models.py
@@ -37,7 +37,7 @@ class CheckResult:
 @dataclass
 class SentinelConfig:
     """Configuration for Sentinel monitoring."""
-    target_base_url: str = "http://localhost:8000"
+    target_base_url: str = "http://localhost:8001"
     check_interval_seconds: int = 60
     alert_threshold_failures: int = 3
     webhook_url: Optional[str] = None


### PR DESCRIPTION
## Summary
- Fixes S1-S10 health checks by pointing to correct FastAPI service  
- FastAPI runs on port 8001, MCP server on port 8000
- Should resolve HTTP 404 errors in Sentinel monitoring

## Changes
- Updated `SentinelConfig.target_base_url` from port 8000 to 8001

## Testing
- Sentinel will now check FastAPI endpoints correctly
- Should see green health checks instead of 404 errors

🤖 Generated with [Claude Code](https://claude.ai/code)