### PR TITLE
fix: Extend API container health check timeout to resolve deployment failures

### DIFF
--- a/dockerfiles/Dockerfile.api
+++ b/dockerfiles/Dockerfile.api
@@ -60,8 +60,8 @@ ENV LOG_LEVEL=info
 ENV ENVIRONMENT=production
 
 # Health check for API on port 8001
-# Using curl to check the actual API health endpoint
-HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=10 \
+# Extended startup period and reduced frequency to handle backend initialization delays
+HEALTHCHECK --interval=45s --timeout=15s --start-period=180s --retries=8 \
     CMD curl -f http://localhost:8001/api/v1/health/live || exit 1
 
 # Switch to non-root user


### PR DESCRIPTION
## Problem
The deployment is failing with error: `container veris-memory-dev-api-1 is unhealthy`

This occurs because the API container health check times out during startup while waiting for backends (Neo4j, Qdrant, Redis) to fully initialize.

## Root Cause Analysis
After examining recent PRs (#118, #117, #101) that implemented graceful startup and backend connection fixes, the remaining issue is the Docker health check timing parameters being too aggressive for the startup sequence.

## Solution
Extended health check parameters in `dockerfiles/Dockerfile.api`:

- **Start period**: 120s → 180s (3 minutes for full backend initialization)
- **Timeout**: 10s → 15s (more time for health endpoint response)  
- **Interval**: 30s → 45s (less frequent checks during startup)
- **Retries**: 10 → 8 (fewer retries but longer overall grace period)

## Why This Fixes It
- Provides backends sufficient time to fully initialize before health checks begin
- Reduces check frequency to avoid overwhelming the initializing system
- Maintains robust health monitoring while being startup-tolerant
- Complements recent graceful startup improvements (#118) and service connection fixes (#101)

## Testing
This fix addresses the Docker container health check timing issue that prevents successful deployment even when the underlying services are functioning correctly.

Resolves the "container veris-memory-dev-api-1 is unhealthy" deployment error.

🤖 Generated with [Claude Code](https://claude.ai/code)