### PR TITLE
🚨 CRITICAL: Fix IndentationErrors preventing API container from starting

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -106,7 +106,7 @@ async def lifespan(app: FastAPI):
             config_result = validate_all_configs()
             base_config = config_result.get("config", {})
             if not config_result.get("valid", False):
-            api_logger.warning(f"⚠️ Configuration validation failed: {config_result}")
+                api_logger.warning(f"⚠️ Configuration validation failed: {config_result}")
         
             # Initialize SSL configuration manager
             ssl_manager = SSLConfigManager(base_config)
@@ -114,8 +114,8 @@ async def lifespan(app: FastAPI):
             # Validate SSL certificates if configured
             ssl_validation = ssl_manager.validate_ssl_certificates()
             for backend, valid in ssl_validation.items():
-            if not valid:
-                api_logger.warning(f"⚠️ SSL certificate validation failed for {backend}")
+                if not valid:
+                    api_logger.warning(f"⚠️ SSL certificate validation failed for {backend}")
                 
         except Exception as config_error:
             api_logger.warning(f"⚠️ Configuration setup failed: {config_error}")


### PR DESCRIPTION
## 🔥 CRITICAL DEPLOYMENT BLOCKER FIXED

### The Problem
Deployment has been failing with:
```
dependency failed to start: container veris-memory-dev-api-1 is unhealthy
```

### Root Cause Discovery
Through deep investigation, found **Python IndentationErrors** in `src/api/main.py` that completely prevent the API from starting:

```python
# Line 109 - BROKEN:
if not config_result.get("valid", False):
api_logger.warning(...)  # ❌ IndentationError

# Line 117 - BROKEN:  
for backend, valid in ssl_validation.items():
if not valid:  # ❌ IndentationError
```

### Impact
1. Python interpreter crashes immediately with `IndentationError`
2. API container never starts (no process running)
3. Health checks fail because there's literally no service to check
4. Container marked as "unhealthy" indefinitely
5. **All deployments fail**

### The Fix
Corrected indentation at both locations:
```python
# Line 109 - FIXED:
if not config_result.get("valid", False):
    api_logger.warning(...)  # ✅ Correct indentation

# Line 117 - FIXED:
for backend, valid in ssl_validation.items():
    if not valid:  # ✅ Correct indentation
```

### Verification
```bash
# Syntax check - PASSES:
$ python3 -m py_compile src/api/main.py
# (no output = success)

# API startup - WORKS:
$ python3 -m src.api.main
INFO: Uvicorn running on http://0.0.0.0:8001
⚠️ API: Real backends failed: ['Qdrant', 'Neo4j', 'Redis']. API will start in degraded mode.
# ✅ Starts successfully even without backends
```

### Why This Went Undetected
- Recent PRs (#118, #117, #101) fixed graceful startup logic
- But the API couldn't benefit from these improvements
- **It couldn't even start due to syntax errors**

### Deployment Impact
This PR resolves the critical blocker preventing all deployments. The API container will now:
1. Start successfully 
2. Pass health checks
3. Allow deployments to complete

**Urgent merge recommended** to unblock GitHub Actions workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)