### PR TITLE
fix: Fix YAML syntax error in deploy-dev.yml workflow

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -349,14 +349,7 @@ jobs:
                 docker logs "$API_CONTAINER" 2>&1 || echo "No logs"
                 echo ""
                 echo "🔍 Debugging info:"
-                docker inspect "$API_CONTAINER" --format '
-Status: {{.State.Status}}
-Exit Code: {{.State.ExitCode}}
-Error: {{.State.Error}}
-Started: {{.State.StartedAt}}
-Finished: {{.State.FinishedAt}}
-Command: {{join .Config.Cmd " "}}
-' 2>/dev/null || true
+                docker inspect "$API_CONTAINER" --format 'Status: {{.State.Status}}, Exit Code: {{.State.ExitCode}}, Error: {{.State.Error}}, Started: {{.State.StartedAt}}, Finished: {{.State.FinishedAt}}, Command: {{join .Config.Cmd " "}}' 2>/dev/null || true
                 echo ""
                 echo "📁 Files in container:"
                 docker run --rm --entrypoint ls veris-memory-dev-api:latest -la /app/ 2>&1 | head -20 || true


### PR DESCRIPTION
## Fix for Invalid Workflow File Error

### Problem
GitHub Actions reports:
```
Invalid workflow file: .github/workflows/deploy-dev.yml#L359
You have an error in your yaml syntax on line 359
```

### Root Cause
The multi-line string in the `docker inspect` command was not properly formatted for YAML:

```yaml
# BROKEN - Line 352-359
docker inspect "$API_CONTAINER" --format '
Status: {{.State.Status}}
Exit Code: {{.State.ExitCode}}
Error: {{.State.Error}}
Started: {{.State.StartedAt}}
Finished: {{.State.FinishedAt}}
Command: {{join .Config.Cmd " "}}
' 2>/dev/null || true
```

### Solution
Converted to single-line format to maintain valid YAML syntax:

```yaml
# FIXED - Single line
docker inspect "$API_CONTAINER" --format 'Status: {{.State.Status}}, Exit Code: {{.State.ExitCode}}, Error: {{.State.Error}}, Started: {{.State.StartedAt}}, Finished: {{.State.FinishedAt}}, Command: {{join .Config.Cmd " "}}' 2>/dev/null || true
```

### Impact
- ✅ Fixes workflow validation error
- ✅ Allows deployment workflow to run
- ✅ Maintains all debugging information
- ✅ Simple, minimal change

This is a critical fix to unblock the deployment workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)