### PR TITLE
fix: Explicit Git safe directory for Claude Code Review

### DIFF
--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -73,9 +73,10 @@ RUN mkdir -p \
     context/logs/signatures
 
 # Set up git safe directory (for GitHub Actions)
-# Both paths are needed: /github/workspace for some contexts, /__w/* for GitHub Actions runner
+# Multiple paths needed for different GitHub Actions contexts
 RUN git config --global --add safe.directory /github/workspace && \
-    git config --global --add safe.directory '/__w/*/*' && \
+    git config --global --add safe.directory /__w/veris-memory/veris-memory && \
+    git config --global --add safe.directory /__w && \
     git config --global --add safe.directory '*'
 
 # Labels for GitHub Container Registry


### PR DESCRIPTION
## Problem
The Claude Code Review workflow is failing with:
```
fatal: detected dubious ownership in repository at '/__w/veris-memory/veris-memory'
exit code 128
```

## Root Cause
The wildcard pattern `/__w/*/*` in the Dockerfile wasn't being interpreted correctly.

## Solution
Add explicit Git safe directory configuration:
- `/__w/veris-memory/veris-memory` - The exact path from the error
- `/__w` - Parent directory as backup
- `*` - Wildcard as final fallback

## Testing
Once this is merged and the CI container is rebuilt, the Claude Code Review should work without Git errors.

## Related
- Continues fix from PR #136
- Resolves exit code 128 in Claude workflow